### PR TITLE
use `readxl::read_excel` to read in xls data

### DIFF
--- a/instructions.R
+++ b/instructions.R
@@ -6,7 +6,7 @@
 
 #install packages:
 
-install.packages("rprojroot")
+install.packages("rprojroot", "readxl")
 
 #step 3: generate jester dataset
 

--- a/jesterDatasets/get_data.R
+++ b/jesterDatasets/get_data.R
@@ -1,7 +1,7 @@
 generate_data <- function(x){
 
 #Code for obtaining the Jester dataset from Ken Goldberg's website (http://goldberg.berkeley.edu/jester-data/)
-library(gdata)
+library(readxl)
 
 #####################################################
 #Download data from website and save it into a matrix
@@ -21,7 +21,7 @@ download.file(urls[i],temp)
 unzip(zipfile = temp, exdir = temp2)
 
 name <- paste0("jester-data-",i,".xls")
-data[[i]] <- read.xls(file.path(temp2, name))
+data[[i]] <- read_excel(file.path(temp2, name), col_names = FALSE)
 unlink(c(temp, temp2))
 
 


### PR DESCRIPTION
This way we get rid of `gdata::read.xls`’s external dependency on Perl, which created troubles on tardis. I also fixed a bug where the participant in the first row of each Excel file was turned into the column names.